### PR TITLE
Update test worker route

### DIFF
--- a/.dwollaci.yml
+++ b/.dwollaci.yml
@@ -24,7 +24,7 @@ stages:
         nvm install
         set -x
         npm install -g serverless serverless-cloudflare-workers
-        export CLOUDFLARE_WORKER_ROUTE='fisync.dwolla.com/test-worker'
+        export CLOUDFLARE_WORKER_ROUTE='fisync.dwolla.com'
         sbt deploy
 additionalJobs:
   - name: End Scheduled Maintenance


### PR DESCRIPTION
We may need to include a wildcard in the route if it is intended to cover any path on a given hostname. This will test whether omitting the wildcard still works.