### PR TITLE
Resolve serverless v3 breaking changes

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,11 +1,11 @@
 configValidationMode: off
 frameworkVersion: ^2.39.1
 
-service:
-  name: scheduled-maintenance
-  config:
-    accountId: ${env:CLOUDFLARE_ACCOUNT_ID}
-    zoneId: ${env:CLOUDFLARE_ZONE_ID}
+service: scheduled-maintenance
+
+config:
+  accountId: ${env:CLOUDFLARE_ACCOUNT_ID}
+  zoneId: ${env:CLOUDFLARE_ZONE_ID}
 
 provider:
   name: cloudflare


### PR DESCRIPTION
The previous deploy failed because of a serverless issue. Upon further research, I found that serverless v3 has deprecated some features we were using. Namely:
```yml
# old syntax
service:
  name: foo-service

# new syntax
service: foo-service
```